### PR TITLE
Fixed URL of jar in installation script

### DIFF
--- a/installDependencies.sh
+++ b/installDependencies.sh
@@ -1,4 +1,4 @@
-curl -O https://github.com/nhaarman/ListViewAnimations/blob/master/com.haarman.listviewanimations-1.9.jar
+curl -O https://raw.github.com/nhaarman/ListViewAnimations/master/com.haarman.listviewanimations-1.9.jar
 
 mvn install:install-file -Dfile=./com.haarman.listviewanimations-1.9.jar -DgroupId=com.haarman.listviewanimations -DartifactId=ListViewAnimations -Dversion=1.9 -Dpackaging=jar
 


### PR DESCRIPTION
Turns out that URLs of GitHub files are hard to get right, you have to manually compose them as:
https://raw.github.com/user/repo/branch/file
